### PR TITLE
Disabling the profile x-header so C10 users can use the docker image hassle-free

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -121,4 +121,4 @@ adblock_lists = [
 # https://doc.scrapinghub.com/crawlera.html#request-headers
 [xheaders]
 cookies = "disable"
-profile = "desktop"
+# profile = "desktop"


### PR DESCRIPTION
Proposed fix for #7 