### PR TITLE
Set default debug mode to false

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@
 
 # Should we run this tool in debug mode or not. Basically, this makes
 # the tool more verbose on stderr.
-debug = true
+debug = false
 
 # This tool talks with Crawlera and Crawlera has its own TLS certificate
 # authority. This option defines if if we need to verify TLS certificate


### PR DESCRIPTION
Hi,

Using the proxy docker image, we discovered that since the debug configuration is computed as follows: 
```
func (c *Config) MaybeSetDebug(value bool) {
	c.Debug = c.Debug || value
}
```
Having a default of `true` was actually not overwritten by setting the `CRAWLERA_HEADLESS_DEBUG` env var.